### PR TITLE
Splitter

### DIFF
--- a/1_fetch/src/get_site_data.R
+++ b/1_fetch/src/get_site_data.R
@@ -1,7 +1,6 @@
 # download data for each site
 # packages needed: tidyverse, dataRetrieval
-get_site_data <- function(sites_info, state, parameter) {
-  site_info <- filter(sites_info, state_cd == state)
+get_site_data <- function(site_info, state, parameter) {
   message(sprintf('  Retrieving data for %s-%s', state, state))
 
   # simulate an unreliable web service or internet connection by causing random failures

--- a/1_fetch/src/get_state_inventory.R
+++ b/1_fetch/src/get_state_inventory.R
@@ -1,0 +1,3 @@
+get_state_inventory <- function(sites_info, state) {
+  site_info <- dplyr::filter(sites_info, state_cd == state)
+}

--- a/1_fetch/src/get_state_inventory.R
+++ b/1_fetch/src/get_state_inventory.R
@@ -1,3 +1,0 @@
-get_state_inventory <- function(sites_info, state) {
-  site_info <- dplyr::filter(sites_info, state_cd == state)
-}

--- a/_targets.R
+++ b/_targets.R
@@ -7,11 +7,12 @@ tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr", "rnaturale
 
 # Load functions needed by targets below
 source("1_fetch/src/find_oldest_sites.R")
+source("1_fetch/src/get_state_inventory.R")
 source("1_fetch/src/get_site_data.R")
 source("3_visualize/src/map_sites.R")
 
 # Configuration
-states <- c('WI','MN','MI', 'IL')
+states <- c('WI','MN','MI','IL','IN','IA')
 parameter <- c('00060')
 
 # Targets
@@ -21,7 +22,9 @@ list(
 
   tar_map(
     values = tibble(state_abb = states),
-    tar_target(data, get_site_data(oldest_active_sites, state_abb, parameter))
+    tar_target(nwis_inventory, get_state_inventory(oldest_active_sites,
+                                                   state_abb)),
+    tar_target(data, get_site_data(nwis_inventory, state_abb, parameter))
     # Insert step for tallying data here
     # Insert step for plotting data here
   ),

--- a/_targets.R
+++ b/_targets.R
@@ -22,8 +22,8 @@ list(
 
   tar_map(
     values = tibble(state_abb = states),
-    tar_target(nwis_inventory, get_state_inventory(oldest_active_sites,
-                                                   state_abb)),
+    tar_target(nwis_inventory, dplyr::filter(oldest_active_sites,
+                                             state_cd == state_abb)),
     tar_target(data, get_site_data(nwis_inventory, state_abb, parameter))
     # Insert step for tallying data here
     # Insert step for plotting data here


### PR DESCRIPTION
Addressing #6

Adding a new splitter step to the pipeline.

Previously, getting the data for the oldest site in each state relied directly on `oldest_active_sites`; this meant that when a new state was added, `oldest_active_sites` updated, which then instructed the makefile to redownload all of the data for the previously added states.

Now, `oldest_active_sites` is split into separate state-specific targets. These state-specific targets are not changed when a new state is added to `oldest_active_sites`. Therefore, the process is more efficient because when a new state is added, only that new state's data must be fetched.

The code associated with this PR was evaluated by adding 'IN' and 'IA' to the states object. When `tar_make()` was ran, the following targets were built:

* `oldest_active_sites`
* `nwis_inventory_*`
* `site_map_png`
* `data_IA`
* `data_IN`

Meaning that the following targets were skipped:

* `data_MI`
* `data_WI`
* `data_MN`
* `data_IL`