### PR TITLE
Combiners

### DIFF
--- a/2_process/src/summarize_targets.R
+++ b/2_process/src/summarize_targets.R
@@ -1,0 +1,8 @@
+summarize_targets <- function(ind_file, ...) {
+  ind_tbl <- tar_meta(c(...)) %>%
+    select(tar_name = name, filepath = path, hash = data) %>%
+    mutate(filepath = unlist(filepath))
+
+  readr::write_csv(ind_tbl, ind_file)
+  return(ind_file)
+}

--- a/2_process/src/tally_site_obs.R
+++ b/2_process/src/tally_site_obs.R
@@ -9,3 +9,7 @@ tally_site_obs <- function(site_data) {
     group_by(Site, State, Year) %>%
     summarize(NumObs = length(which(!is.na(Value))), .groups = "keep")
 }
+
+combine_obs_tallies <- function(...) {
+  bind_rows(...)
+}

--- a/3_visualize/log/summary_state_timeseries.csv
+++ b/3_visualize/log/summary_state_timeseries.csv
@@ -1,8 +1,8 @@
 tar_name,filepath,hash
-timeseries_png_WI,3_visualize/out/timeseries_WI.png,97f518d622d579fa
-timeseries_png_MN,3_visualize/out/timeseries_MN.png,38cfd72eef75b8d1
-timeseries_png_MI,3_visualize/out/timeseries_MI.png,ed975c9e6aa588e6
-timeseries_png_IL,3_visualize/out/timeseries_IL.png,d4c53bc276448e4c
-timeseries_png_IN,3_visualize/out/timeseries_IN.png,496787a085fd962c
+timeseries_png_WI,3_visualize/out/timeseries_WI.png,065dfa77d32f2c97
+timeseries_png_MN,3_visualize/out/timeseries_MN.png,8d58e00267edb4ac
+timeseries_png_MI,3_visualize/out/timeseries_MI.png,187e2e7ff222f7dd
+timeseries_png_IL,3_visualize/out/timeseries_IL.png,c86d79dd8028692a
+timeseries_png_IN,3_visualize/out/timeseries_IN.png,29b6c9e28275db48
 timeseries_png_IA,3_visualize/out/timeseries_IA.png,74c9716c279d086b
-timeseries_png_OH,3_visualize/out/timeseries_OH.png,c2b367cca3ca63c0
+timeseries_png_OH,3_visualize/out/timeseries_OH.png,de44b029f498fe51

--- a/3_visualize/log/summary_state_timeseries.csv
+++ b/3_visualize/log/summary_state_timeseries.csv
@@ -1,0 +1,8 @@
+tar_name,filepath,hash
+timeseries_png_WI,3_visualize/out/timeseries_WI.png,97f518d622d579fa
+timeseries_png_MN,3_visualize/out/timeseries_MN.png,38cfd72eef75b8d1
+timeseries_png_MI,3_visualize/out/timeseries_MI.png,ed975c9e6aa588e6
+timeseries_png_IL,3_visualize/out/timeseries_IL.png,d4c53bc276448e4c
+timeseries_png_IN,3_visualize/out/timeseries_IN.png,496787a085fd962c
+timeseries_png_IA,3_visualize/out/timeseries_IA.png,74c9716c279d086b
+timeseries_png_OH,3_visualize/out/timeseries_OH.png,c2b367cca3ca63c0

--- a/_targets.R
+++ b/_targets.R
@@ -5,45 +5,79 @@ library(tibble)
 options(tidyverse.quiet = TRUE)
 library(tidyverse)
 
-tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr", "rnaturalearth", "cowplot", "lubridate"))
+tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr",
+                            "rnaturalearth", "cowplot", "lubridate",
+                            "leaflet", "leafpop", "htmlwidgets"))
 
 # Load functions needed by targets below
 source("1_fetch/src/find_oldest_sites.R")
 source("1_fetch/src/get_site_data.R")
 source("2_process/src/tally_site_obs.R")
+source("2_process/src/summarize_targets.R")
 source("3_visualize/src/map_sites.R")
+source("3_visualize/src/plot_data_coverage.R")
 source("3_visualize/src/plot_site_data.R")
+source("3_visualize/src/map_timeseries.R")
 
 # Configuration
-states <- c('WI','MN','MI','IL','IN','IA')
+states <- c('WI','MN','MI','IL','IN','IA','OH')
 parameter <- c('00060')
+
+mapped_by_state_targets <- tar_map(
+  tibble(state_abb = states) %>%
+    mutate(state_plot_files = sprintf("3_visualize/out/timeseries_%s.png", state_abb)),
+  tar_target(nwis_inventory, dplyr::filter(oldest_active_sites,
+                                           state_cd == state_abb)),
+  tar_target(nwis_data, get_site_data(nwis_inventory, state_abb, parameter)),
+  # Insert step for tallying data here
+  tar_target(tally, tally_site_obs(nwis_data)),
+  # Insert step for plotting data here
+  tar_target(timeseries_png,
+             plot_site_data(state_plot_files,
+                            nwis_data,
+                            parameter),
+             format = 'file'),
+  names = state_abb
+)
 
 # Targets
 list(
   # Identify oldest sites
   tar_target(oldest_active_sites, find_oldest_sites(states, parameter)),
-
-  tar_map(
-    tibble(state_abb = states) %>%
-      mutate(state_plot_files = sprintf("3_visualize/out/timeseries_%s.png", state_abb)),
-    tar_target(nwis_inventory, dplyr::filter(oldest_active_sites,
-                                             state_cd == state_abb)),
-    tar_target(nwis_data, get_site_data(nwis_inventory, state_abb, parameter)),
-    # Insert step for tallying data here
-    tar_target(tally, tally_site_obs(nwis_data)),
-    # Insert step for plotting data here
-    tar_target(timeseries_png,
-               plot_site_data(state_plot_files,
-                              nwis_data,
-                              parameter),
-               format = 'file'),
-    names = state_abb
+  # Reference/define the split targets
+  mapped_by_state_targets,
+  # Combine the split targets tallies
+  tar_combine(
+    obs_tallies,
+    mapped_by_state_targets[[3]],
+    command = combine_obs_tallies(!!!.x)),
+  # Combine the split targets time series
+  tar_combine(
+    summary_state_timeseries_csv,
+    mapped_by_state_targets[[4]],
+    command = summarize_targets('3_visualize/log/summary_state_timeseries.csv', !!!.x),
+    format="file"
   ),
+  # Create coverage plot for the combined tallies
+  tar_target(data_coverage_png,
+             plot_data_coverage(obs_tallies,
+                                '3_visualize/out/data_coverage.png',
+                                parameter),
+             format = 'file'),
 
   # Map oldest sites
   tar_target(
     site_map_png,
     map_sites("3_visualize/out/site_map.png", oldest_active_sites),
+    format = "file"
+  ),
+  # Map the time series interactively
+  tar_target(
+    timeseries_map_html,
+    map_timeseries(
+      oldest_active_sites,
+      summary_state_timeseries_csv,
+      out_file = '3_visualize/out/timeseries_map.html'),
     format = "file"
   )
 )

--- a/_targets.R
+++ b/_targets.R
@@ -37,7 +37,8 @@ mapped_by_state_targets <- tar_map(
                             nwis_data,
                             parameter),
              format = 'file'),
-  names = state_abb
+  names = state_abb,
+  unlist = FALSE
 )
 
 # Targets
@@ -49,12 +50,12 @@ list(
   # Combine the split targets tallies
   tar_combine(
     obs_tallies,
-    mapped_by_state_targets[[3]],
+    mapped_by_state_targets$tally,
     command = combine_obs_tallies(!!!.x)),
   # Combine the split targets time series
   tar_combine(
     summary_state_timeseries_csv,
-    mapped_by_state_targets[[4]],
+    mapped_by_state_targets$timeseries_png,
     command = summarize_targets('3_visualize/log/summary_state_timeseries.csv', !!!.x),
     format="file"
   ),


### PR DESCRIPTION
Addressing #10 

A lot of things are covered in this PR. Previously the data in the pipeline was split at the state-level, but little was done with that split data (except individual time series of data availability). With this PR:

* The split data are combined to:
    * Create an aggregate dataframe for all states (`obs_tallies`)
    * Create a summarizing plot showing data availability through time for the oldest site in each state (`data_coverage_png`)
* Additionally, while we still do not track the state-specific time series plots, we now track a fpath/hash of those images (located in `visualize/log/`) that will allow us to know if they have changed
* Lastly, we produce an interactive html map (`timeseries_map_html`) that locates and displays the state-specific time series

![ds-pipelines-targets-3-combinersinteractivemap](https://user-images.githubusercontent.com/18230221/131403077-f4cc1813-bdce-4f6e-9fc7-b9f490a25731.png)